### PR TITLE
fix: cursor movement logic inconsistencies

### DIFF
--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -133,6 +133,12 @@ impl Application {
                 + 2,
         );
 
+        let current_column = self
+            .editor
+            .position
+            .column
+            .saturating_add(self.editor.scroll_offset.column);
+
         let width = self
             .terminal.size()?
             .width as usize;

--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -141,10 +141,8 @@ impl Application {
             KeyCode::Up => {
                 if self.editor.position.row > 0 {
                     self.editor.position.row -= 1;
-                    self.editor.position.column = std::cmp::min(
-                        self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column),
-                        past_row_length
-                    );
+                    self.editor.position.column =
+                        std::cmp::min(self.editor.position.history.column, past_row_length);
                     if self.editor.position.column < width {
                         self.editor.scroll_offset.column = 0;
                     } else {
@@ -154,11 +152,10 @@ impl Application {
             }
 
             KeyCode::Down => {
-                let next_row_index = self.editor.position.row.saturating_add(1);
-                if next_row_index <= self.editor.document.rows.len().saturating_sub(1) {
+                if self.editor.position.row.saturating_add(1) <= self.editor.document.rows.len().saturating_sub(1) {
                     self.editor.position.row += 1;
                     self.editor.position.column =
-                        std::cmp::min(self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column), next_row_length);
+                        std::cmp::min(self.editor.position.history.column, next_row_length);
                     if self.editor.position.column < width {
                         self.editor.scroll_offset.column = 0;
                     } else {
@@ -170,15 +167,16 @@ impl Application {
             KeyCode::Left => {
                 if self.editor.position.column > 0 {
                     self.editor.position.column -= 1;
+                    self.editor.position.history.column = self.editor.position.column;
                     if self.editor.position.column < self.editor.scroll_offset.column {
                         self.editor.scroll_offset.column = self.editor.position.column.saturating_sub(width);
                     }
                 } else if self.editor.position.row > 0 {
                     self.editor.position.row -= 1;
                     self.editor.position.column = past_row_length;
+                    self.editor.position.history.column = self.editor.position.column;
                     if self.editor.position.column >= self.editor.scroll_offset.column + width {
-                        let scroll_by = (self.editor.position.column + 1).saturating_sub(width);
-                        self.editor.scroll_offset.column = scroll_by;
+                        self.editor.scroll_offset.column = (self.editor.position.column + 1).saturating_sub(width);
                     }
                 }
             }
@@ -191,10 +189,10 @@ impl Application {
                         self.editor.scroll_offset.column += 1;
                     }
                 } else {
-                    let next_row_index = self.editor.position.row.saturating_add(1);
-                    if next_row_index <= self.editor.document.rows.len().saturating_sub(1) {
+                    if self.editor.position.row.saturating_add(1) <= self.editor.document.rows.len().saturating_sub(1) {
                         self.editor.position.row += 1;
                         self.editor.position.column = 0;
+                        self.editor.position.history.column = 0;
                         self.editor.scroll_offset.column = 0;
                     }
                 }

--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -133,12 +133,6 @@ impl Application {
                 + 2,
         );
 
-        let current_column = self
-            .editor
-            .position
-            .column
-            .saturating_add(self.editor.scroll_offset.column);
-
         let width = self
             .terminal.size()?
             .width as usize;
@@ -147,7 +141,10 @@ impl Application {
             KeyCode::Up => {
                 if self.editor.position.row > 0 {
                     self.editor.position.row -= 1;
-                    self.editor.position.column = std::cmp::min(self.editor.position.column, past_row_length);
+                    self.editor.position.column = std::cmp::min(
+                        self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column),
+                        past_row_length
+                    );
                     if self.editor.position.column < width {
                         self.editor.scroll_offset.column = 0;
                     } else {
@@ -160,7 +157,8 @@ impl Application {
                 let next_row_index = self.editor.position.row.saturating_add(1);
                 if next_row_index <= self.editor.document.rows.len().saturating_sub(1) {
                     self.editor.position.row += 1;
-                    self.editor.position.column = std::cmp::min(self.editor.position.column, next_row_length);
+                    self.editor.position.column =
+                        std::cmp::min(self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column), next_row_length);
                     if self.editor.position.column < width {
                         self.editor.scroll_offset.column = 0;
                     } else {
@@ -188,6 +186,7 @@ impl Application {
             KeyCode::Right => {
                 if self.editor.position.column < current_row_length {
                     self.editor.position.column += 1;
+                    self.editor.position.history.column = self.editor.position.column;
                     if self.editor.position.column >= self.editor.scroll_offset.column + width {
                         self.editor.scroll_offset.column += 1;
                     }

--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -133,13 +133,12 @@ impl Application {
                 + 2,
         );
 
-        let current_column = self
+        let last_row = self
             .editor
-            .position
-            .column
-            .saturating_add(self.editor.scroll_offset.column);
-
-        let last_row = self.editor.document.rows.len().saturating_sub(1);
+            .document
+            .rows
+            .len()
+            .saturating_sub(1);
 
         match key_code {
             KeyCode::Up => {
@@ -147,6 +146,7 @@ impl Application {
                     self.editor.position.row = self.editor.position.row.saturating_sub(1);
                     self.editor.position.column =
                         std::cmp::min(self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column), past_row_length.saturating_sub(self.editor.scroll_offset.column));
+                    self.editor.position.history.column = self.editor.position.column;
                 }
             }
 
@@ -156,17 +156,19 @@ impl Application {
                         self.editor.scroll_offset.row = self.editor.scroll_offset.row.saturating_add(1);
                         self.editor.position.column =
                             std::cmp::min(self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column), next_row_length.saturating_sub(self.editor.scroll_offset.column));
+                        self.editor.position.history.column = self.editor.position.column;
                     }
 
                     if self.editor.position.row < self.terminal.size()?.height as usize {
                         self.editor.position.row = self.editor.position.row.saturating_add(1);
                         self.editor.position.column =
                             std::cmp::min(self.editor.position.history.column.saturating_sub(self.editor.scroll_offset.column), next_row_length.saturating_sub(self.editor.scroll_offset.column));
+                        self.editor.position.history.column = self.editor.position.column;
                     }
                 }
             }
 
-            KeyCode::Left => {
+          KeyCode::Left => {
                 if self.editor.position.column > 0 || self.editor.position.row > 0 {
                     if self.editor.position.column == 0 && self.editor.position.row > 0 {
                         self.editor.position.row = self.editor.position.row.saturating_sub(1);
@@ -175,9 +177,8 @@ impl Application {
                         self.editor.scroll_offset.column =
                             self.editor.scroll_offset.column.saturating_sub(1);
                         self.editor.position.column = self.editor.position.column.saturating_sub(1);
-                        self.editor.position.history.column =
-                            self.editor.position.history.column.saturating_sub(1);
                     }
+                    self.editor.position.history.column = self.editor.position.column;
                 }
             }
 
@@ -192,9 +193,8 @@ impl Application {
                                 self.editor.scroll_offset.column.saturating_add(1);
                         }
                         self.editor.position.column = self.editor.position.column.saturating_add(1);
-                        self.editor.position.history.column =
-                            self.editor.position.history.column.saturating_add(1);
                     }
+                    self.editor.position.history.column = self.editor.position.column;
                 }
             }
 


### PR DESCRIPTION
### Bug Fixes:
- Fixed cursor movement logic to allow movement to the next line when the right arrow key is pressed at the end of a line, and vice versa.
- Fixed an inconsistency in cursor navigation across lines of varying lengths. The cursor now retains its position based on the shorter line when moving between long and short lines, rather than reverting to its original position.
- Prevented the cursor from moving beyond the start or end of the document.

### Enhancements:
- Used the `len()` method on the `rows` vector of the `Document` struct to determine the total number of rows in the document, ensuring accurate cursor movement and boundary checking.